### PR TITLE
feat: Add User Login API with Credential Verification and JWT

### DIFF
--- a/apps/backend/src/controllers/auth.controller.ts
+++ b/apps/backend/src/controllers/auth.controller.ts
@@ -8,13 +8,13 @@ export const register = async (req: Request, res: Response): Promise<void> => {
     const { email, password } = req.body;
 
     if (!email || !password) {
-      res.status(400).json({ error: "Email and password are required" });
+      res.status(400).json({ error: "Email and password are required." });
       return;
     }
 
     const existingUser = await prisma.user.findUnique({ where: { email } });
     if (existingUser) {
-      res.status(400).json({ error: "Email already registered" });
+      res.status(400).json({ error: "Email already registered." });
       return;
     }
 
@@ -30,7 +30,35 @@ export const register = async (req: Request, res: Response): Promise<void> => {
     const token = signJwt({ userId: user.id });
     res.status(201).json({ token });
   } catch (error) {
-    console.error("❌ REGISTER ERROR:", error); // 👈 로그 찍기
+    console.error("REGISTER ERROR:", error);
+    res.status(500).json({ error: "Internal Server error" });
+  }
+};
+
+export const login = async (req: Request, res: Response): Promise<void> => {
+  try {
+    const { email, password } = req.body;
+    if (!email || !password) {
+      res.status(400).json({ error: "Email and Password is required." });
+      return;
+    }
+
+    const user = await prisma.user.findUnique({ where: { email } });
+    if (!user) {
+      res.status(401).json({ error: "Invalid credentials." });
+      return;
+    }
+
+    const isPasswordCorrect = await bcrypt.compare(password, user.password!);
+    if (!isPasswordCorrect) {
+      res.status(401).json({ error: "Invalid credentials." });
+      return;
+    }
+
+    const token = signJwt({ userId: user.id });
+    res.status(200).json({ token });
+  } catch (error) {
+    console.error("LOGIN ERROR:", error);
     res.status(500).json({ error: "Internal Server error" });
   }
 };

--- a/apps/backend/src/routes/auth.routes.ts
+++ b/apps/backend/src/routes/auth.routes.ts
@@ -1,8 +1,9 @@
 import express from "express";
-import { register } from "../controllers/auth.controller";
+import { register, login } from "../controllers/auth.controller";
 
 const router = express.Router();
 
 router.post("/register", register);
+router.post("/login", login);
 
 export default router;


### PR DESCRIPTION
## 📌 Summary

<!-- PR의 목적과 간단한 요약을 적어주세요 -->

This PR implements the login API, allowing users to authenticate with their credentials.
It verifies email and password, and issues a JWT upon successful login.

---

## 🔧 Changes

<!-- 주요 변경 사항을 bullet point로 요약 -->

- Added `POST /api/auth/login` route
- Created `login` controller:
    - Verifies if user exists
    - Compared bcrypt-hashed password
    - Returns a JWT on succesful authentication
- Added login route to auth router

---

## ✅ Checklist

<!-- PR을 리뷰하거나 머지하기 전에 확인해야 할 항목들 -->

- [o] User can log in with email and pasword
- [o] Bcrypt password comparison implemented
- [o] Error handling for invalid credentials
- [o] JWT returned for valid user

---

## 🔍 Test Instructions (Optional)

<!-- PR 변경사항을 확인하기 위한 테스트 방법이 있다면 -->

1. Run backend server

``` bash
npm run dev
```
2. Register a user (if not already done):
``` bash
curl -X POST http://localhost:4000/api/auth/register \
  -H "Content-Type: application/json" \
  -d '{"email": "test@example.com", "password": "yourpassword"}'
```
3. Log in using the registered credentials
``` bash
curl -X POST http://localhost:4000/api/auth/login \
  -H "Content-Type: application/json" \
  -d '{"email": "test@example.com", "password": "yourpassword"}'
```

---

## 🚨 Breaking Changes (Optional)

<!-- 기존 기능과 충돌하거나 호환되지 않는 사항이 있다면 명시 -->

None

---

## 🤝 Related Issues / PRs

<!-- 연결된 이슈나 PR이 있다면 링크 -->

None
